### PR TITLE
Fix non atomic scratch register readout

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Works with C/C++ via pico-sdk, arduino, and micropython.  Examples are provided 
 
 Pass A and B pins to PIO program and it will keeps track of quadrature position in state machine's "x" register.
 
-To read the current value, force exec an "in" command from "x" register, then read the X value (see example in main.c).
+To read the current value, force exec an "in" command from "y" register, then read the Y value (see example in main.c).
 
-The value of x is an absolute value of the encoder (initialized to 0 on startup).  You can do relative measurements for a menu by capturing the value when the menu starts, but it doesn't support limits currently, so probably the best workaround would be to take the absolute value of the encoder modulo the length of your menu to select determine the position.
+The value of y is an absolute value of the encoder (initialized to 0 on startup).  You can do relative measurements for a menu by capturing the value when the menu starts, but it doesn't support limits currently, so probably the best workaround would be to take the absolute value of the encoder modulo the length of your menu to select determine the position.
 
 # How to use
 * Include [quadrature.pio](src/quadrature.pio) in your project
@@ -29,11 +29,15 @@ quadrature_program_init(pio, sm, offset, QUADRATURE_A_PIN, QUADRATURE_B_PIN);
  ```
 * Read the current value of the encoder from the state machine
 ```c
-pio_sm_exec_wait_blocking(pio, sm, pio_encode_in(pio_x, 32));
+pio_sm_exec_wait_blocking(pio, sm, pio_encode_in(pio_y, 32));
 uint x = pio_sm_get_blocking(pio, sm);
 ```
 
 ## Zeroing/resetting position
+
+Note that the resetting happens on t x scratch register as opposed to y.
+Register y holds just a copy of the final value after full cycle, x is used for
+the actual encoder calculation.
 
 ```c
 pio_sm_exec(pio, sm, pio_encode_set(pio_x, 0));
@@ -48,7 +52,7 @@ Not really applicable for this kind of library, but I'm going to drop this here 
 PIO pio = pio0;
 uint offset, sm;
 void quadrature_sw_callback(uint gpio, uint32_t events) {
-    if(gpio == QUADRATURE_SW_PIN) pio_sm_exec(pio, sm, pio_encode_set(pio_x, 0));
+    if(gpio == QUADRATURE_SW_PIN) pio_sm_exec(pio, sm, pio_encode_set(pio_y, 0));
 }
 int main() {
     stdio_init_all();

--- a/examples/main.c
+++ b/examples/main.c
@@ -17,7 +17,7 @@ int main() {
  
     while (true) {
         sleep_ms(1000);
-        pio_sm_exec_wait_blocking(pio, sm, pio_encode_in(pio_x, 32));
+        pio_sm_exec_wait_blocking(pio, sm, pio_encode_in(pio_y, 32));
         uint x = pio_sm_get_blocking(pio, sm);
         printf("%d\n", x);
     }

--- a/python/quadrature.py
+++ b/python/quadrature.py
@@ -27,6 +27,7 @@ def encoder():
     jmp(x_dec, "nop4")
     label("nop4")
     mov(x, invert(x))
+    mov(y, x)
     wrap()
 
     
@@ -35,6 +36,6 @@ sm1.active(1)
 
 while(True):
     utime.sleep(1)
-    sm1.exec("in_(x, 32)")
+    sm1.exec("in_(y, 32)")
     x = sm1.get()
     print(x)

--- a/src/quadrature.pio
+++ b/src/quadrature.pio
@@ -28,6 +28,7 @@ wait_low:                   ; else
     jmp x--, nop4               ;
 nop4:                           ;
     mov x, !x                   ;
+    mov y, x                    ;
     jmp start                   ; }
 
 % c-sdk {

--- a/src/quadrature.pio.h
+++ b/src/quadrature.pio.h
@@ -13,7 +13,7 @@
 // ---------- //
 
 #define quadrature_wrap_target 0
-#define quadrature_wrap 12
+#define quadrature_wrap 13
 
 static const uint16_t quadrature_program_instructions[] = {
             //     .wrap_target
@@ -29,14 +29,15 @@ static const uint16_t quadrature_program_instructions[] = {
     0xa029, //  9: mov    x, !x                      
     0x004b, // 10: jmp    x--, 11                    
     0xa029, // 11: mov    x, !x                      
-    0x0000, // 12: jmp    0                          
+    0xa041, // 12: mov    y, x                       
+    0x0000, // 13: jmp    0                          
             //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
 static const struct pio_program quadrature_program = {
     .instructions = quadrature_program_instructions,
-    .length = 13,
+    .length = 14,
     .origin = -1,
 };
 


### PR DESCRIPTION
Thank you for very useful implementation of the encoder!

When using it I found a bug for which fix you may be interested in merging it. The issue is: `pio_sm_exec_wait_blocking` executes a give instruction no matter what is being executed in the loop. That is why sometimes the readout is happening in between the  3 operations that are used to increment the counter, copying here one of the 2 increments I am referencing

```
mov x, !x 
    jmp x--, nop1 
nop1:            
    mov x, !x   
```

So if the read happens for exsample to be after the first `mov` of the `jmp` the value is correupted (it is the 2s complement of the values desired).

Example stream of counts with that bug:
```
186492 186496 186500 186504 186508 186511 186515 186519 186523 186527 186531 186534 186538 186542 186546 186550 186554 4294780737 186561 186565 186569 186623 186625 186628 186632 186636 186640 186644 186648
```

Note the sudden high value `4294780737`. But one can notice that 2^32 - 4294780737 = 186559 which would make much more sense :)

So how I fixed it is use the other scrach register (y) to copy over to the final calculated value and read from it. Since mov is a one cycle operation any interuption will give a valid value. X is kept as was and is used for the interim calculation.